### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -102,7 +103,7 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
         }
 
         public File inputStreamToTempFile(InputStream source, String prefix, String suffix) throws IOException {
-                File f = File.createTempFile(prefix, suffix);
+                File f = Files.createTempFile(prefix, suffix).toFile();
                 f.deleteOnExit();
                 FileOutputStream fos = new FileOutputStream(f);
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
@@ -15,6 +15,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.file.Files;
 
 import org.apache.log4j.Logger;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -94,7 +95,7 @@ public class PDFFilter extends MediaFilter
 
             if (useTemporaryFile)
             {
-                tempTextFile = File.createTempFile("dspacepdfextract" + source.hashCode(), ".txt");
+                tempTextFile = Files.createTempFile("dspacepdfextract" + source.hashCode(), ".txt").toFile();
                 tempTextFile.deleteOnExit();
                 writer = new OutputStreamWriter(new FileOutputStream(tempTextFile));
             }

--- a/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
+++ b/dspace-api/src/main/java/org/dspace/checker/DailyReportEmailer.java
@@ -19,6 +19,7 @@ import javax.mail.MessagingException;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -190,8 +191,7 @@ public class DailyReportEmailer
 
             if (directory.exists() && directory.isDirectory())
             {
-                report = File.createTempFile("checker_report", ".txt",
-                        directory);
+                report = Files.createTempFile(directory.toPath(), "checker_report", ".txt").toFile();
             }
             else
             {

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/METSDisseminationCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/METSDisseminationCrosswalk.java
@@ -9,6 +9,7 @@ package org.dspace.content.crosswalk;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -117,7 +118,7 @@ public class METSDisseminationCrosswalk
             String tempDirectory = (ConfigurationManager.getProperty("upload.temp.dir") != null)
                 ? ConfigurationManager.getProperty("upload.temp.dir") : System.getProperty("java.io.tmpdir"); 
 
-            File tempFile = File.createTempFile("METSDissemination" + dso.hashCode(), null, new File(tempDirectory));
+            File tempFile = Files.createTempFile(new File(tempDirectory).toPath(), "METSDissemination" + dso.hashCode(), null).toFile();
             tempFile.deleteOnExit();
 
             // Disseminate METS to temp file

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/RoleCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/RoleCrosswalk.java
@@ -10,6 +10,7 @@ package org.dspace.content.crosswalk;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.sql.SQLException;
 import java.util.List;
 
@@ -187,7 +188,7 @@ public class RoleCrosswalk
             // Create a temporary file to disseminate into
             String tempDirectory = (ConfigurationManager.getProperty("upload.temp.dir") != null)
                 ? ConfigurationManager.getProperty("upload.temp.dir") : System.getProperty("java.io.tmpdir"); 
-            File tempFile = File.createTempFile("RoleCrosswalkDisseminate" + dso.hashCode(), null, new File(tempDirectory));
+            File tempFile = Files.createTempFile(new File(tempDirectory).toPath(), "RoleCrosswalkDisseminate" + dso.hashCode(), null).toFile();
             tempFile.deleteOnExit();
 
             // Initialize our packaging parameters
@@ -317,7 +318,7 @@ public class RoleCrosswalk
         // Create a temporary file to ingest from
         String tempDirectory = (ConfigurationManager.getProperty("upload.temp.dir") != null)
             ? ConfigurationManager.getProperty("upload.temp.dir") : System.getProperty("java.io.tmpdir"); 
-        File tempFile = File.createTempFile("RoleCrosswalkIngest" + dso.hashCode(), null, new File(tempDirectory));
+        File tempFile = Files.createTempFile(new File(tempDirectory).toPath(), "RoleCrosswalkIngest" + dso.hashCode(), null).toFile();
         tempFile.deleteOnExit();
         FileOutputStream fileOutStream = null;
         try

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/S3BitStoreService.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Required;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Map;
 
 /**
@@ -165,7 +166,7 @@ public class S3BitStoreService implements BitStoreService
 	{
         String key = getFullKey(bitstream.getInternalId());
         //Copy istream to temp file, and send the file, with some metadata
-        File scratchFile = File.createTempFile(bitstream.getInternalId(), "s3bs");
+        File scratchFile = Files.createTempFile(bitstream.getInternalId(), "s3bs").toFile();
         try {
             FileUtils.copyInputStreamToFile(in, scratchFile);
             Long contentLength = Long.valueOf(scratchFile.length());

--- a/dspace-api/src/test/java/org/dspace/core/PathsClassLoaderTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/PathsClassLoaderTest.java
@@ -12,6 +12,7 @@ import com.sun.org.apache.bcel.internal.generic.ClassGen;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import org.junit.After;
@@ -55,7 +56,7 @@ public class PathsClassLoaderTest
 
         // Create a name for a temporary class file.
         try {
-            classFile = File.createTempFile(FILENAME_PREFIX, CLASS_FILENAME_SUFFIX);
+            classFile = Files.createTempFile(FILENAME_PREFIX, CLASS_FILENAME_SUFFIX).toFile();
             classFile.deleteOnExit();
         } catch (IOException e) {
             System.err.println(e.getMessage());
@@ -82,7 +83,7 @@ public class PathsClassLoaderTest
         // Create a JAR containing the empty class.
         JarOutputStream jar;
         try {
-            jarFile = File.createTempFile(FILENAME_PREFIX, JAR_FILENAME_SUFFIX);
+            jarFile = Files.createTempFile(FILENAME_PREFIX, JAR_FILENAME_SUFFIX).toFile();
             jarFile.deleteOnExit();
             String jarFileName = jarFile.getName();
             jarClassName = jarFileName.substring(0,

--- a/dspace-jspui/src/main/java/org/dspace/app/webui/json/SubmissionLookupJSONRequest.java
+++ b/dspace-jspui/src/main/java/org/dspace/app/webui/json/SubmissionLookupJSONRequest.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -266,9 +267,7 @@ public class SubmissionLookupJSONRequest extends JSONRequest
                         uploadDir = null;
                     }
                 }
-                File file = File.createTempFile("submissionlookup-loader",
-                                                ".temp",
-                                                uploadDir);
+                File file = Files.createTempFile(uploadDir.toPath(), "submissionlookup-loader", ".temp").toFile();
                 BufferedOutputStream out = new BufferedOutputStream(
                         new FileOutputStream(file));
                 Utils.bufferedCopy(io, out);

--- a/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowBatchImportUtils.java
+++ b/dspace-xmlui/src/main/java/org/dspace/app/xmlui/aspect/administrative/FlowBatchImportUtils.java
@@ -8,6 +8,7 @@
 package org.dspace.app.xmlui.aspect.administrative;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.sql.*;
 import java.util.*;
 import org.apache.cocoon.environment.*;
@@ -132,7 +133,7 @@ public class FlowBatchImportUtils {
 
                 File mapFile = null;
                 try {
-                    mapFile = File.createTempFile(file.getName(), ".map", itemImportService.getTempWorkDirFile());
+                    mapFile = Files.createTempFile(itemImportService.getTempWorkDirFile().toPath(), file.getName(), ".map").toFile();
                 } catch (IOException e) {
                     log.error("BatchImportUI Unable to create mapfile", e);
                     result.setContinue(false);


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
